### PR TITLE
Update readmes with setup docs

### DIFF
--- a/cmd/configuration/readme.md
+++ b/cmd/configuration/readme.md
@@ -1,0 +1,1 @@
+Contém a validação e o carregamento das variáveis de ambiente utilizadas pelo projeto.

--- a/cmd/migrate/server/readme.md
+++ b/cmd/migrate/server/readme.md
@@ -1,0 +1,1 @@
+Reservado para scripts de migração de banco de dados. Ainda não possui implementações.

--- a/cmd/readme.md
+++ b/cmd/readme.md
@@ -1,0 +1,1 @@
+Este diretório agrupa os comandos de inicialização da aplicação. Aqui ficam o servidor HTTP e demais utilidades executadas via `go run ./cmd/...`.

--- a/cmd/server/readme.md
+++ b/cmd/server/readme.md
@@ -1,0 +1,1 @@
+Implementação do servidor HTTP utilizando o framework Gin e o registro das rotas da aplicação.

--- a/internal/app/configuration/readme.md
+++ b/internal/app/configuration/readme.md
@@ -1,0 +1,1 @@
+Configurações específicas da camada de aplicação. Atualmente serve apenas como placeholder para futuras definições.

--- a/internal/app/middleware/readme.md
+++ b/internal/app/middleware/readme.md
@@ -1,0 +1,1 @@
+Diretório destinado aos middlewares utilizados pelo Gin (autenticação, logging, etc.). No momento não há implementações.

--- a/internal/app/readme.md
+++ b/internal/app/readme.md
@@ -1,0 +1,1 @@
+Camada de aplicação onde residem controllers, handlers e serviços. Novos módulos de negócio devem ser criados aqui.

--- a/internal/configuration/readme.md
+++ b/internal/configuration/readme.md
@@ -1,0 +1,1 @@
+Módulos de configuração globais, incluindo carregamento de variáveis de ambiente e parâmetros de inicialização.

--- a/internal/infrastructure/readme.md
+++ b/internal/infrastructure/readme.md
@@ -1,0 +1,1 @@
+Implementações de infraestrutura e integrações externas. Contém, por exemplo, o módulo de conexão com o PostgreSQL.

--- a/readme.md
+++ b/readme.md
@@ -1,22 +1,59 @@
 # BASIC-CRUD-GO
 
-Este é um projeto de portfólio desenvolvido em **Golang**, utilizando os princípios de **Domain-Driven Design (DDD)**.  
-A aplicação implementa um CRUD completo para o domínio `admin`, com foco em organização de camadas, boas práticas de arquitetura e extensibilidade para sistemas reais.
+Este é um projeto de portfólio desenvolvido em **Golang**, utilizando os princípios de **Domain-Driven Design (DDD)**.
+A aplicação implementa um CRUD básico para o domínio `admin`, servindo como exemplo de organização de camadas e boas práticas de arquitetura.
 
 ---
 
 ## 🧱 Estrutura do Projeto
-
 ```bash
 .
 ├── cmd/                    # Ponto de entrada da aplicação
 │   ├── configuration/      # Carregamento de configurações
 │   └── server/             # Inicialização do servidor HTTP
 ├── internal/
-│   ├── app/
-│   │   ├── admin/          # Lógica da aplicação (CRUD Admin)
-│   │   ├── configuration/  # Configuração aplicada no contexto da app
-│   │   └── middleware/     # Middlewares da aplicação
-│   ├── infrastructure/     # Banco de dados, serviços externos
-│   └── configuration/      # Configs globais da aplicação
-└── main.go                 # Entrada alternativa ou atalho
+│   ├── app/                # Camada de aplicação (handlers, serviços, etc.)
+│   ├── infrastructure/     # Banco de dados e serviços externos
+│   └── configuration/      # Configurações globais
+└── main.go                 # Entrada principal
+```
+
+## 🚀 Instalação
+1. Clone o repositório
+   ```bash
+   git clone https://github.com/usuario/basic-crud-go.git
+   cd basic-crud-go
+   ```
+2. Copie o arquivo `.env.example` para `.env` e ajuste os valores conforme seu ambiente.
+3. Instale as dependências (opcional, caso não sejam baixadas automaticamente):
+   ```bash
+   go mod download
+   ```
+
+## 🔧 Configuração de Variáveis de Ambiente
+As variáveis são lidas do arquivo `.env`. Abaixo um exemplo dos principais parâmetros:
+```env
+ENV=DEV
+LISTEN_SERVER=0.0.0.0
+HTTP_PORT=8080
+HTTPS=FALSE
+HTTPS_PORT=8081
+DNS="example.dns.org"
+LOG_LEVEL=1
+LOG_DATABASE=FALSE
+RECOVERY_EMAIL="email@example.org"
+RECOVERY_PWD="Ex@mpl3PwD"
+DATABASE_URL=127.0.0.1
+DATABASE_PORT=5432
+DATABASE_USER=user_acess
+DATABASE_PW=pwExampl3
+DATABASE_NAME=users_db
+DATABASE_SSL=disable
+```
+
+## ▶️ Como Executar
+Execute o projeto com o comando abaixo:
+```bash
+go run main.go
+```
+A API será exposta em `http://<LISTEN_SERVER>:<HTTP_PORT>` ou HTTPS caso habilitado.


### PR DESCRIPTION
## Summary
- extend main readme with installation steps, env variables and run instructions
- add short descriptions to empty readme files inside the project structure

## Testing
- `go vet ./...` *(fails: proxy access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6865901890e0832b8525d146061a9e26