### PR TITLE
Handle db query errors in CLI

### DIFF
--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -43,14 +43,26 @@ func HandleCLI() {
 
 	case "--status":
 		db := postgres.InitPostgres()
-		rows, _ := db.Query(`SELECT filename, applied_at FROM migrations_applied ORDER BY applied_at`)
+		rows, err := db.Query(`SELECT filename, applied_at FROM migrations_applied ORDER BY applied_at`)
+		if err != nil {
+			fmt.Printf("❌ Failed to query migrations: %v\n", err)
+			return
+		}
 		defer rows.Close()
+
 		fmt.Println("📄 Applied migrations:")
 		for rows.Next() {
 			var name string
 			var appliedAt string
-			rows.Scan(&name, &appliedAt)
+			if err := rows.Scan(&name, &appliedAt); err != nil {
+				fmt.Printf("❌ Failed to read migration: %v\n", err)
+				return
+			}
 			fmt.Printf("  ✅ %s at %s\n", name, appliedAt)
+		}
+		if err := rows.Err(); err != nil {
+			fmt.Printf("❌ Rows error: %v\n", err)
+			return
 		}
 
 	case "--help":


### PR DESCRIPTION
## Summary
- catch errors returned from `db.Query` in CLI status command
- handle errors during row scanning and after iteration
- format `cmd/cli/cli.go` with gofmt

## Testing
- `go test ./...` *(fails: Forbidden for module downloads)*
- `go vet ./...` *(fails: Forbidden for module downloads)*

------
https://chatgpt.com/codex/tasks/task_e_6866c0ad0828832b8b4f84458959fcff