### PR TITLE
Add reusable auth middleware

### DIFF
--- a/internal/app/admin/enterprise/handler/v1/enterprise/enterprise.go
+++ b/internal/app/admin/enterprise/handler/v1/enterprise/enterprise.go
@@ -1,29 +1,46 @@
 package enterprise
 
 import (
+	authRepo "basic-crud-go/internal/app/admin/auth/repository"
+	authService "basic-crud-go/internal/app/admin/auth/service"
 	"basic-crud-go/internal/app/admin/enterprise/controller"
-	"basic-crud-go/internal/app/admin/enterprise/repository"
+	entRepo "basic-crud-go/internal/app/admin/enterprise/repository"
 	"basic-crud-go/internal/app/admin/enterprise/service"
+	adminMW "basic-crud-go/internal/app/admin/middleware/service"
+	permRepo "basic-crud-go/internal/app/admin/permission/repository"
+	permService "basic-crud-go/internal/app/admin/permission/service"
+	userRepo "basic-crud-go/internal/app/admin/user/repository"
+	userService "basic-crud-go/internal/app/admin/user/service"
+	mw "basic-crud-go/internal/app/middleware"
 	"basic-crud-go/internal/infrastructure/db/postgres"
 
 	"github.com/gin-gonic/gin"
 )
 
 func RegisterEnterpriseRoutes(router *gin.RouterGroup) {
-	// Repository
-	repo := repository.NewRepositoryImpl(postgres.GetDB())
-	//Service
-	svc := service.NewEnterpriseService(repo)
-	//Controller
+	db := postgres.GetDB()
+	// Enterprise layer
+	entRepository := entRepo.NewRepositoryImpl(db)
+	svc := service.NewEnterpriseService(entRepository)
 	ctrl := controller.NewEnterpriseController(svc)
+
+	// Middleware dependencies
+	userRepository := userRepo.NewUserRepositoryImpl(db)
+	userSvc := userService.NewUserService(userRepository, svc)
+	permRepository := permRepo.NewRepositoryImpl(db)
+	permSvc := permService.NewPermissionService(permRepository, userSvc)
+	authRepository := authRepo.NewAuthRepositoryImpl(db)
+	authSvc := authService.NewAuthService(authRepository, userSvc, permSvc)
+	mwSvc := adminMW.NewMiddlewareService(userSvc, authSvc, permSvc)
+	authMW := mw.NewAuth(mwSvc)
 
 	group := router.Group("/")
 	{
-		group.POST("", ctrl.CreateEnterpriseHandler)
+		group.POST("", authMW.Handler("create-enterprise"), ctrl.CreateEnterpriseHandler)
 		group.GET("read", ctrl.ReadEnterprisesHandler)
 		group.GET("read/:cnpj", ctrl.ReadEnterpriseHandler)
-		group.PUT("", ctrl.UpdateEnterpriseHandler)
-		group.DELETE(":cnpj", ctrl.DeleteEnterpriseHandler)
+		group.PUT("", authMW.Handler("update-enterprise"), ctrl.UpdateEnterpriseHandler)
+		group.DELETE(":cnpj", authMW.Handler("delete-enterprise"), ctrl.DeleteEnterpriseHandler)
 	}
 
 }

--- a/internal/app/middleware/auth.go
+++ b/internal/app/middleware/auth.go
@@ -1,0 +1,53 @@
+package middleware
+
+import (
+	adminmw "basic-crud-go/internal/app/admin/middleware/service"
+	"basic-crud-go/internal/configuration/logger"
+	"basic-crud-go/internal/configuration/rest_err"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Auth is a reusable middleware handler that validates API keys
+// and checks for specific permissions.
+type Auth struct {
+	service adminmw.MiddlewareService
+}
+
+// NewAuth creates a new Auth middleware instance.
+func NewAuth(service adminmw.MiddlewareService) *Auth {
+	return &Auth{service: service}
+}
+
+// Handler returns a gin.HandlerFunc that validates the request's
+// Authorization header and ensures the user has the required permission.
+func (a *Auth) Handler(requiredCode string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if len(authHeader) < 8 || !strings.HasPrefix(authHeader, "Bearer ") {
+			restErr := rest_err.NewBadRequestError("Missing or malformed Authorization header")
+			c.AbortWithStatusJSON(restErr.Code, restErr)
+			return
+		}
+		apiKey := strings.TrimSpace(authHeader[7:])
+
+		identity, err := a.service.ValidateApiKey(c.Request.Context(), apiKey)
+		if err != nil {
+			logger.LogWithAutoFuncName(logger.Warning, "AuthMiddleware", err.Error())
+			restErr := rest_err.NewForbiddenError("Invalid or expired token")
+			c.AbortWithStatusJSON(restErr.Code, restErr)
+			return
+		}
+
+		if requiredCode != "" && !a.service.HasPermission(requiredCode, identity.Permissions) {
+			restErr := rest_err.NewForbiddenError("Permission denied")
+			c.AbortWithStatusJSON(restErr.Code, restErr)
+			return
+		}
+
+		// store identity in context for handlers
+		c.Set("identity", identity)
+		c.Next()
+	}
+}


### PR DESCRIPTION
## Summary
- implement reusable `Auth` middleware outside of app layer
- wire middleware into enterprise routes to check permissions

## Testing
- `go test ./...` *(fails: downloading toolchain blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688d1f33877c832bab9d49db75b8317a