### PR TITLE
Add global auth middleware initialization

### DIFF
--- a/cmd/server/routes.go
+++ b/cmd/server/routes.go
@@ -6,6 +6,8 @@ import (
 	enterpriseHandler "basic-crud-go/internal/app/admin/enterprise/handler"
 	permissionHandler "basic-crud-go/internal/app/admin/permission/handler"
 	userHandler "basic-crud-go/internal/app/admin/user/handler"
+	"basic-crud-go/internal/infrastructure/db/postgres"
+	middleware "basic-crud-go/internal/middleware"
 	"github.com/gin-gonic/gin"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
@@ -13,6 +15,7 @@ import (
 
 func RegisterRoutes(router *gin.Engine) {
 	InitSwagger(router)
+	middleware.SetupDefault(postgres.GetDB())
 	userHandler.RegisterUserRoutes(router)
 	enterpriseHandler.RegisterEnterpriseRoutes(router)
 	permissionHandler.RegisterPermissionRoutes(router)

--- a/internal/app/admin/enterprise/handler/v1/enterprise/enterprise.go
+++ b/internal/app/admin/enterprise/handler/v1/enterprise/enterprise.go
@@ -2,28 +2,27 @@ package enterprise
 
 import (
 	"basic-crud-go/internal/app/admin/enterprise/controller"
-	"basic-crud-go/internal/app/admin/enterprise/repository"
+	entRepo "basic-crud-go/internal/app/admin/enterprise/repository"
 	"basic-crud-go/internal/app/admin/enterprise/service"
 	"basic-crud-go/internal/infrastructure/db/postgres"
+	mw "basic-crud-go/internal/middleware"
 
 	"github.com/gin-gonic/gin"
 )
 
 func RegisterEnterpriseRoutes(router *gin.RouterGroup) {
-	// Repository
-	repo := repository.NewRepositoryImpl(postgres.GetDB())
-	//Service
-	svc := service.NewEnterpriseService(repo)
-	//Controller
+	db := postgres.GetDB()
+	entRepository := entRepo.NewRepositoryImpl(db)
+	svc := service.NewEnterpriseService(entRepository)
 	ctrl := controller.NewEnterpriseController(svc)
 
 	group := router.Group("/")
 	{
-		group.POST("", ctrl.CreateEnterpriseHandler)
+		group.POST("", mw.AuthMiddleware("create-enterprise"), ctrl.CreateEnterpriseHandler)
 		group.GET("read", ctrl.ReadEnterprisesHandler)
 		group.GET("read/:cnpj", ctrl.ReadEnterpriseHandler)
-		group.PUT("", ctrl.UpdateEnterpriseHandler)
-		group.DELETE(":cnpj", ctrl.DeleteEnterpriseHandler)
+		group.PUT("", mw.AuthMiddleware("update-enterprise"), ctrl.UpdateEnterpriseHandler)
+		group.DELETE(":cnpj", mw.AuthMiddleware("delete-enterprise"), ctrl.DeleteEnterpriseHandler)
 	}
 
 }

--- a/internal/app/middleware/readme.md
+++ b/internal/app/middleware/readme.md
@@ -1,1 +1,0 @@
-Diretório destinado aos middlewares utilizados pelo Gin (autenticação, logging, etc.). No momento não há implementações.

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -1,0 +1,95 @@
+package middleware
+
+import (
+	"database/sql"
+	"strings"
+
+	authRepo "basic-crud-go/internal/app/admin/auth/repository"
+	authService "basic-crud-go/internal/app/admin/auth/service"
+	entRepo "basic-crud-go/internal/app/admin/enterprise/repository"
+	entService "basic-crud-go/internal/app/admin/enterprise/service"
+	adminmw "basic-crud-go/internal/app/admin/middleware/service"
+	permRepo "basic-crud-go/internal/app/admin/permission/repository"
+	permService "basic-crud-go/internal/app/admin/permission/service"
+	userRepo "basic-crud-go/internal/app/admin/user/repository"
+	userService "basic-crud-go/internal/app/admin/user/service"
+	"basic-crud-go/internal/configuration/logger"
+	"basic-crud-go/internal/configuration/rest_err"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Auth is a reusable middleware handler that validates API keys
+// and checks for specific permissions.
+type Auth struct {
+	service adminmw.MiddlewareService
+}
+
+var defaultAuth *Auth
+
+// NewAuth creates a new Auth middleware instance with an existing service.
+func NewAuth(service adminmw.MiddlewareService) *Auth {
+	return &Auth{service: service}
+}
+
+// SetupDefault initializes the package-level Auth instance using the provided
+// database connection. It should be called once during application startup.
+func SetupDefault(db *sql.DB) {
+	defaultAuth = NewAuthMiddleware(db)
+}
+
+// AuthMiddleware returns a gin.HandlerFunc that uses the default middleware
+// instance. It panics if SetupDefault was not called before.
+func AuthMiddleware(code string) gin.HandlerFunc {
+	if defaultAuth == nil {
+		panic("auth middleware not initialized")
+	}
+	return defaultAuth.Handler(code)
+}
+
+// NewAuthMiddleware initializes all required dependencies using the provided
+// database connection and returns a ready-to-use Auth middleware instance.
+func NewAuthMiddleware(db *sql.DB) *Auth {
+	entRepository := entRepo.NewRepositoryImpl(db)
+	entSvc := entService.NewEnterpriseService(entRepository)
+	userRepository := userRepo.NewUserRepositoryImpl(db)
+	userSvc := userService.NewUserService(userRepository, entSvc)
+	permRepository := permRepo.NewRepositoryImpl(db)
+	permSvc := permService.NewPermissionService(permRepository, userSvc)
+	authRepository := authRepo.NewAuthRepositoryImpl(db)
+	authSvc := authService.NewAuthService(authRepository, userSvc, permSvc)
+	mwSvc := adminmw.NewMiddlewareService(userSvc, authSvc, permSvc)
+	return &Auth{service: mwSvc}
+}
+
+// Handler returns a gin.HandlerFunc that validates the request's
+// Authorization header and ensures the user has the required permission.
+func (a *Auth) Handler(requiredCode string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if len(authHeader) < 8 || !strings.HasPrefix(authHeader, "Bearer ") {
+			restErr := rest_err.NewBadRequestError("Missing or malformed Authorization header")
+			c.AbortWithStatusJSON(restErr.Code, restErr)
+			return
+		}
+		apiKey := strings.TrimSpace(authHeader[7:])
+
+		identity, err := a.service.ValidateApiKey(c.Request.Context(), apiKey)
+		if err != nil {
+			logger.LogWithAutoFuncName(logger.Warning, "AuthMiddleware", err.Error())
+			restErr := rest_err.NewForbiddenError("Invalid or expired token")
+			c.AbortWithStatusJSON(restErr.Code, restErr)
+			return
+		}
+
+		if requiredCode != "" && !a.service.HasPermission(requiredCode, identity.Permissions) {
+			restErr := rest_err.NewForbiddenError("Permission denied")
+			c.AbortWithStatusJSON(restErr.Code, restErr)
+			return
+		}
+
+		// store identity in context for handlers
+		c.Set("identity", identity)
+		c.Next()
+	}
+}

--- a/internal/middleware/readme.md
+++ b/internal/middleware/readme.md
@@ -1,0 +1,24 @@
+# Middleware
+
+Este diretório armazena middlewares reutilizáveis para o framework Gin.
+
+## Auth
+
+O middleware `Auth` valida o token enviado no cabeçalho `Authorization` e executa a verificação de permissões para rotas protegidas.
+
+A inicialização deve ocorrer apenas uma vez na aplicação, conforme exemplo abaixo:
+
+```go
+// cmd/server/routes.go
+import (
+    "basic-crud-go/internal/infrastructure/db/postgres"
+    middleware "basic-crud-go/internal/middleware"
+)
+
+func RegisterRoutes(r *gin.Engine) {
+    middleware.SetupDefault(postgres.GetDB())
+    enterprise.RegisterEnterpriseRoutes(r)
+}
+```
+
+Use `mw.AuthMiddleware("codigo-permissao")` nas rotas que necessitam autenticação.

--- a/readme.md
+++ b/readme.md
@@ -60,3 +60,5 @@ A API será exposta em `http://<LISTEN_SERVER>:<HTTP_PORT>` ou HTTPS caso habili
 
 ## 📝 Licença
 Este projeto está licenciado sob os termos da [MIT License](LICENSE).
+\n## Middleware
+Consulte `internal/middleware/readme.md` para saber como inicializar e reutilizar o middleware de autenticação nas rotas.


### PR DESCRIPTION
## Summary
- introduce `SetupDefault` and `AuthMiddleware` helpers
- register middleware globally in server routing
- simplify enterprise route registration
- update docs with middleware instructions

## Testing
- `go test ./...` *(fails: downloading toolchain blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688d1f33877c832bab9d49db75b8317a