### PR TITLE
feat: add reusable auth middleware

### DIFF
--- a/cmd/server/routes.go
+++ b/cmd/server/routes.go
@@ -3,9 +3,20 @@ package server
 import (
 	_ "basic-crud-go/docs"
 	authHandler "basic-crud-go/internal/app/admin/auth/handler"
+	authRepo "basic-crud-go/internal/app/admin/auth/repository"
+	authService "basic-crud-go/internal/app/admin/auth/service"
 	enterpriseHandler "basic-crud-go/internal/app/admin/enterprise/handler"
+	enterpriseRepo "basic-crud-go/internal/app/admin/enterprise/repository"
+	enterpriseService "basic-crud-go/internal/app/admin/enterprise/service"
+	mwService "basic-crud-go/internal/app/admin/middleware/service"
 	permissionHandler "basic-crud-go/internal/app/admin/permission/handler"
+	permissionRepo "basic-crud-go/internal/app/admin/permission/repository"
+	permissionService "basic-crud-go/internal/app/admin/permission/service"
 	userHandler "basic-crud-go/internal/app/admin/user/handler"
+	userRepo "basic-crud-go/internal/app/admin/user/repository"
+	userService "basic-crud-go/internal/app/admin/user/service"
+	middleware "basic-crud-go/internal/app/middleware"
+	"basic-crud-go/internal/infrastructure/db/postgres"
 	"github.com/gin-gonic/gin"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
@@ -13,8 +24,9 @@ import (
 
 func RegisterRoutes(router *gin.Engine) {
 	InitSwagger(router)
+	mw := initAuthMiddleware()
 	userHandler.RegisterUserRoutes(router)
-	enterpriseHandler.RegisterEnterpriseRoutes(router)
+	enterpriseHandler.RegisterEnterpriseRoutes(router, mw)
 	permissionHandler.RegisterPermissionRoutes(router)
 	authHandler.RegisterAuthRoutes(router)
 }
@@ -22,4 +34,23 @@ func RegisterRoutes(router *gin.Engine) {
 func InitSwagger(router *gin.Engine) {
 	router.StaticFS("/docs", gin.Dir("./docs", true))
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+}
+
+func initAuthMiddleware() *middleware.AuthMiddleware {
+	db := postgres.GetDB()
+
+	entRepo := enterpriseRepo.NewRepositoryImpl(db)
+	entSvc := enterpriseService.NewEnterpriseService(entRepo)
+
+	uRepo := userRepo.NewUserRepositoryImpl(db)
+	uSvc := userService.NewUserService(uRepo, entSvc)
+
+	permRepo := permissionRepo.NewRepositoryImpl(db)
+	permSvc := permissionService.NewPermissionService(permRepo, uSvc)
+
+	aRepo := authRepo.NewAuthRepositoryImpl(db)
+	aSvc := authService.NewAuthService(aRepo, uSvc, permSvc)
+
+	mwSvc := mwService.NewMiddlewareService(uSvc, aSvc, permSvc)
+	return middleware.NewAuthMiddleware(mwSvc)
 }

--- a/internal/app/admin/enterprise/handler/handler.go
+++ b/internal/app/admin/enterprise/handler/handler.go
@@ -2,11 +2,12 @@ package handler
 
 import (
 	v1 "basic-crud-go/internal/app/admin/enterprise/handler/v1"
+	middleware "basic-crud-go/internal/app/middleware"
 
 	"github.com/gin-gonic/gin"
 )
 
-func RegisterEnterpriseRoutes(router *gin.Engine) {
+func RegisterEnterpriseRoutes(router *gin.Engine, mw *middleware.AuthMiddleware) {
 	enterpriseGroup := router.Group("/enterprise")
-	v1.RegisterV1Routes(enterpriseGroup)
+	v1.RegisterV1Routes(enterpriseGroup, mw)
 }

--- a/internal/app/admin/enterprise/handler/v1/enterprise/enterprise.go
+++ b/internal/app/admin/enterprise/handler/v1/enterprise/enterprise.go
@@ -4,12 +4,13 @@ import (
 	"basic-crud-go/internal/app/admin/enterprise/controller"
 	"basic-crud-go/internal/app/admin/enterprise/repository"
 	"basic-crud-go/internal/app/admin/enterprise/service"
+	middleware "basic-crud-go/internal/app/middleware"
 	"basic-crud-go/internal/infrastructure/db/postgres"
 
 	"github.com/gin-gonic/gin"
 )
 
-func RegisterEnterpriseRoutes(router *gin.RouterGroup) {
+func RegisterEnterpriseRoutes(router *gin.RouterGroup, mw *middleware.AuthMiddleware) {
 	// Repository
 	repo := repository.NewRepositoryImpl(postgres.GetDB())
 	//Service
@@ -19,11 +20,11 @@ func RegisterEnterpriseRoutes(router *gin.RouterGroup) {
 
 	group := router.Group("/")
 	{
-		group.POST("", ctrl.CreateEnterpriseHandler)
-		group.GET("read", ctrl.ReadEnterprisesHandler)
-		group.GET("read/:cnpj", ctrl.ReadEnterpriseHandler)
-		group.PUT("", ctrl.UpdateEnterpriseHandler)
-		group.DELETE(":cnpj", ctrl.DeleteEnterpriseHandler)
+		group.POST("", mw.AuthMiddleware("create-enterprise"), ctrl.CreateEnterpriseHandler)
+		group.GET("read", mw.AuthMiddleware("read-enterprise"), ctrl.ReadEnterprisesHandler)
+		group.GET("read/:cnpj", mw.AuthMiddleware("read-enterprise"), ctrl.ReadEnterpriseHandler)
+		group.PUT("", mw.AuthMiddleware("update-enterprise"), ctrl.UpdateEnterpriseHandler)
+		group.DELETE(":cnpj", mw.AuthMiddleware("delete-enterprise"), ctrl.DeleteEnterpriseHandler)
 	}
 
 }

--- a/internal/app/admin/enterprise/handler/v1/v1.go
+++ b/internal/app/admin/enterprise/handler/v1/v1.go
@@ -2,11 +2,12 @@ package v1
 
 import (
 	enterprise "basic-crud-go/internal/app/admin/enterprise/handler/v1/enterprise"
+	middleware "basic-crud-go/internal/app/middleware"
 
 	"github.com/gin-gonic/gin"
 )
 
-func RegisterV1Routes(router *gin.RouterGroup) {
+func RegisterV1Routes(router *gin.RouterGroup, mw *middleware.AuthMiddleware) {
 	v1Group := router.Group("/v1")
-	enterprise.RegisterEnterpriseRoutes(v1Group)
+	enterprise.RegisterEnterpriseRoutes(v1Group, mw)
 }

--- a/internal/app/middleware/auth.go
+++ b/internal/app/middleware/auth.go
@@ -1,0 +1,41 @@
+package middleware
+
+import (
+	adminMiddlewareService "basic-crud-go/internal/app/admin/middleware/service"
+	"basic-crud-go/internal/configuration/rest_err"
+	"github.com/gin-gonic/gin"
+)
+
+type AuthMiddleware struct {
+	service adminMiddlewareService.MiddlewareService
+}
+
+func NewAuthMiddleware(service adminMiddlewareService.MiddlewareService) *AuthMiddleware {
+	return &AuthMiddleware{service: service}
+}
+
+// AuthMiddleware validates API key and required permission.
+func (m *AuthMiddleware) AuthMiddleware(requiredCode string) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		authHeader := ctx.GetHeader("Authorization")
+		if len(authHeader) < 8 || authHeader[:7] != "Bearer " {
+			restErr := rest_err.NewBadRequestError("Missing or malformed Authorization header")
+			ctx.AbortWithStatusJSON(restErr.Code, restErr)
+			return
+		}
+		apiKey := authHeader[7:]
+		identity, err := m.service.ValidateApiKey(ctx.Request.Context(), apiKey)
+		if err != nil {
+			restErr := rest_err.NewForbiddenError("Invalid credentials")
+			ctx.AbortWithStatusJSON(restErr.Code, restErr)
+			return
+		}
+		if requiredCode != "" && !m.service.HasPermission(requiredCode, identity.Permissions) {
+			restErr := rest_err.NewForbiddenError("Permission denied")
+			ctx.AbortWithStatusJSON(restErr.Code, restErr)
+			return
+		}
+		ctx.Set("identity", identity)
+		ctx.Next()
+	}
+}


### PR DESCRIPTION
## Summary
- implement reusable AuthMiddleware with permission validation
- wire middleware into enterprise routes and initialize once in server setup

## Testing
- `go test ./...` *(fails: go.mod requires go >= 1.24.2 (running go 1.23.8))*

------
https://chatgpt.com/codex/tasks/task_e_68909fec9b20832ba58c29e9c2a659ad