### PR TITLE
Fix environment mode initialization

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -12,12 +12,22 @@ import (
 )
 
 func InitServer() *gin.Engine {
-	router := gin.Default()
+	environment := env.GetEnvironment()
 	devCors, prodCors := envServer.GetCorsOrigins()
-	if env.GetEnvironment() == "DEV" {
+
+	switch environment {
+	case "DEV":
 		fmt.Println("Running in DEV")
 		gin.SetMode(gin.DebugMode)
-		// Cors set
+	case "PROD":
+		fmt.Println("Running in PROD")
+		gin.SetMode(gin.ReleaseMode)
+	}
+
+	router := gin.Default()
+
+	switch environment {
+	case "DEV":
 		config := cors.Config{
 			AllowOrigins: []string{
 				fmt.Sprintf("http://%s", devCors),
@@ -28,11 +38,7 @@ func InitServer() *gin.Engine {
 			AllowCredentials: true,
 		}
 		router.Use(cors.New(config))
-	}
-	if env.GetEnvironment() == "PROD" {
-		fmt.Println("Running in PROD")
-		gin.SetMode(gin.ReleaseMode)
-		// Cors set
+	case "PROD":
 		config := cors.Config{
 			AllowOrigins:     []string{fmt.Sprintf("https://%s", prodCors)},
 			AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},


### PR DESCRIPTION
## Summary
- ensure Gin's mode is set before creating the router
- refactor CORS setup based on environment

## Testing
- `GOTOOLCHAIN=local go test ./...` *(fails: go.mod requires go >= 1.24.2 (running go 1.23.8; GOTOOLCHAIN=local))*

------
https://chatgpt.com/codex/tasks/task_e_68b5f05096cc832b9b40021873c9a82a